### PR TITLE
Add packages.txt to Include weasyprint Dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ logs/
 __pycache__
 reports_generated/
 .config
+venv/

--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,1 @@
+weasyprint


### PR DESCRIPTION
This PR adds a packages.txt file to the project to ensure that the weasyprint dependency is installed before the Streamlit app starts. The pango-view dependency was missing, and without it, the deployment would fail. By adding this file, we ensure the necessary system dependencies are installed during deployment.